### PR TITLE
fixed redirect: new Url contains host and port

### DIFF
--- a/src/main/java/mousio/etcd4j/transport/EtcdNettyClient.java
+++ b/src/main/java/mousio/etcd4j/transport/EtcdNettyClient.java
@@ -117,9 +117,18 @@ public class EtcdNettyClient implements EtcdClientImpl {
   @SuppressWarnings("unchecked")
   protected <R> void connect(final EtcdRequest<R> etcdRequest, final ConnectionState connectionState)
       throws IOException {
+    
+    URI uri = uris[connectionState.uriIndex];
+    
+    // when we are called from a redirect, the url in the request contains also host and port!
+    String requestUrl = etcdRequest.getUrl();
+    if(requestUrl.contains("://")){
+        uri = URI.create(requestUrl);
+    }
+
     // Start the connection attempt.
     final ChannelFuture connectFuture = bootstrap.clone()
-        .connect(uris[connectionState.uriIndex].getHost(), uris[connectionState.uriIndex].getPort());
+        .connect(uri.getHost(), uri.getPort());
 
     final Channel channel = connectFuture.channel();
     etcdRequest.getPromise().attachNettyPromise(


### PR DESCRIPTION
Hi, I found an issue with redirects: the url which you get with the location header in the redirect response contains also host and port, so you need to use that one and not the initial host and port. See https://github.com/jurmous/etcd4j/blob/master/src/main/java/mousio/etcd4j/transport/EtcdKeyResponseHandler.java#L47.

Redirects appear when you run etcd in a cluster. One machine will be the leader and all request are redirected to that leader. I have a test setup using vagrant, see https://github.com/slintes/etcdTest.

Greetings, Marc

PS: not sure if "requestUrl.contains("://")" makes sense, was just my first idea...
