### PR TITLE
added etcdIndex to response

### DIFF
--- a/src/main/java/mousio/etcd4j/responses/EtcdKeysResponse.java
+++ b/src/main/java/mousio/etcd4j/responses/EtcdKeysResponse.java
@@ -10,6 +10,7 @@ public class EtcdKeysResponse {
 
   public final EtcdKeyAction action;
   public final EtcdNode node;
+  public Integer etcdIndex;
   public EtcdNode prevNode;
 
   /**

--- a/src/main/java/mousio/etcd4j/transport/EtcdKeyResponseHandler.java
+++ b/src/main/java/mousio/etcd4j/transport/EtcdKeyResponseHandler.java
@@ -59,9 +59,16 @@ public class EtcdKeyResponseHandler extends SimpleChannelInboundHandler<FullHttp
     }
 
     try {
-      this.promise.setSuccess(
-          EtcdKeysResponseParser.parse(response.content())
-      );
+      EtcdKeysResponse etcdKeysResponse = EtcdKeysResponseParser.parse(response.content());
+      String etcdIndex = response.headers().get("X-Etcd-Index");
+      if (etcdIndex != null) {
+        try {
+          etcdKeysResponse.etcdIndex = Integer.parseInt(etcdIndex); 
+        } catch (Exception e) {
+          logger.error("could not parse X-Etcd-Index header", e);
+        }
+      }
+      this.promise.setSuccess(etcdKeysResponse);
     }
     // Catches both parsed EtcdExceptions and parsing exceptions
     catch (Exception e) {


### PR DESCRIPTION
Hi again,

for watches we need the X-Etcd-Index header of a response, see [0] and [1].

Greetings, Marc

[0] https://github.com/coreos/etcd/blob/9ba35bc95e51c1bb219226a522e2a613bfa1ba34/Documentation/api.md#response-headers
[1] https://github.com/coreos/etcd/pull/1082#issuecomment-56444616
