### PR TITLE
Allow waitIndex and prevIndex arguments to be of type long

### DIFF
--- a/src/main/java/mousio/etcd4j/requests/EtcdKeyDeleteRequest.java
+++ b/src/main/java/mousio/etcd4j/requests/EtcdKeyDeleteRequest.java
@@ -40,7 +40,7 @@ public class EtcdKeyDeleteRequest extends EtcdKeyRequest {
    * @param prevIndex to set on key
    * @return Itself for chaining
    */
-  public EtcdKeyDeleteRequest prevIndex(int prevIndex) {
+  public EtcdKeyDeleteRequest prevIndex(long prevIndex) {
     this.requestParams.put("prevIndex", prevIndex + "");
     return this;
   }

--- a/src/main/java/mousio/etcd4j/requests/EtcdKeyGetRequest.java
+++ b/src/main/java/mousio/etcd4j/requests/EtcdKeyGetRequest.java
@@ -51,7 +51,7 @@ public class EtcdKeyGetRequest extends EtcdKeyRequest {
    * @param waitIndex to wait for
    * @return Itself for chaining
    */
-  public EtcdKeyGetRequest waitForChange(int waitIndex) {
+  public EtcdKeyGetRequest waitForChange(long waitIndex) {
     this.waitForChange();
     this.requestParams.put("waitIndex", waitIndex + "");
     return this;


### PR DESCRIPTION
In jurmous/etcd4j#10 most index arguments changed to `long`, but I ran into two more `int` cases.
