### PR TITLE
Allow request timeout values to be of type long

### DIFF
--- a/src/main/java/mousio/etcd4j/requests/EtcdKeyDeleteRequest.java
+++ b/src/main/java/mousio/etcd4j/requests/EtcdKeyDeleteRequest.java
@@ -65,7 +65,7 @@ public class EtcdKeyDeleteRequest extends EtcdKeyRequest {
     return this;
   }
 
-  @Override public EtcdKeyDeleteRequest timeout(int timeout, TimeUnit unit) {
+  @Override public EtcdKeyDeleteRequest timeout(long timeout, TimeUnit unit) {
     super.timeout(timeout, unit);
     return this;
   }

--- a/src/main/java/mousio/etcd4j/requests/EtcdKeyGetRequest.java
+++ b/src/main/java/mousio/etcd4j/requests/EtcdKeyGetRequest.java
@@ -96,7 +96,7 @@ public class EtcdKeyGetRequest extends EtcdKeyRequest {
     return this.wait;
   }
 
-  @Override public EtcdKeyGetRequest timeout(int timeout, TimeUnit unit) {
+  @Override public EtcdKeyGetRequest timeout(long timeout, TimeUnit unit) {
     super.timeout(timeout, unit);
     return this;
   }

--- a/src/main/java/mousio/etcd4j/requests/EtcdKeyPostRequest.java
+++ b/src/main/java/mousio/etcd4j/requests/EtcdKeyPostRequest.java
@@ -45,7 +45,7 @@ public class EtcdKeyPostRequest extends EtcdKeyRequest {
     return this;
   }
 
-  @Override public EtcdKeyPostRequest timeout(int timeout, TimeUnit unit) {
+  @Override public EtcdKeyPostRequest timeout(long timeout, TimeUnit unit) {
     super.timeout(timeout, unit);
     return this;
   }

--- a/src/main/java/mousio/etcd4j/requests/EtcdKeyPutRequest.java
+++ b/src/main/java/mousio/etcd4j/requests/EtcdKeyPutRequest.java
@@ -88,7 +88,7 @@ public class EtcdKeyPutRequest extends EtcdKeyRequest {
     return this;
   }
 
-  @Override public EtcdKeyPutRequest timeout(int timeout, TimeUnit unit) {
+  @Override public EtcdKeyPutRequest timeout(long timeout, TimeUnit unit) {
     super.timeout(timeout, unit);
     return this;
   }

--- a/src/main/java/mousio/etcd4j/requests/EtcdRequest.java
+++ b/src/main/java/mousio/etcd4j/requests/EtcdRequest.java
@@ -24,7 +24,7 @@ public abstract class EtcdRequest<R> {
 
   private EtcdResponsePromise<R> promise;
 
-  private int timeout = -1;
+  private long timeout = -1l;
   private TimeUnit timeoutUnit = TimeUnit.SECONDS;
   private HttpRequest httpRequest;
   private String url;
@@ -98,7 +98,7 @@ public abstract class EtcdRequest<R> {
    *
    * @return timeout in milliseconds
    */
-  public int getTimeout() {
+  public long getTimeout() {
     return timeout;
   }
 
@@ -109,7 +109,7 @@ public abstract class EtcdRequest<R> {
    * @param unit    time unit for timeout
    * @return Itself for chaining
    */
-  public EtcdRequest timeout(int timeout, TimeUnit unit) {
+  public EtcdRequest timeout(long timeout, TimeUnit unit) {
     this.timeout = timeout;
     this.timeoutUnit = unit;
     return this;


### PR DESCRIPTION
I propose to change the request timeout argument to `long`. This is more common and allows people to safely use milli/micro/nanosecond TimeUnits.
