### PR TITLE
leading slash leads to unnecessary  redirects

### DIFF
--- a/src/main/java/mousio/etcd4j/requests/EtcdKeyRequest.java
+++ b/src/main/java/mousio/etcd4j/requests/EtcdKeyRequest.java
@@ -37,6 +37,9 @@ public class EtcdKeyRequest extends EtcdRequest<EtcdKeysResponse> {
    * @return EtcdKeysRequest for chaining
    */
   public EtcdKeyRequest setKey(String key) {
+    if (key.startsWith("/")){
+      key = key.substring(1);
+    }
     this.key = key;
     return this;
   }


### PR DESCRIPTION
Hi,

we have 2 issues with keys that have a leading slash:
- They lead to unnecessary redirects, where the double slash is reduced to a single slash (e.g. [nioEventLoopGroup-2-2] WARN mousio.etcd4j.transport.EtcdKeyResponseHandler - redirect for /v2/keys//etcd4jTestDir/etcd4jTest?value=test to /v2/keys/etcd4jTestDir/etcd4jTest?value=test)
- In our setup a put with a leading slash silently fails... no exception, nothing special in the logs, only the value is not stored in etcd. Unfortunately I could not reproduce this in a test class...

So I just added a check for a leading slash in setKey() of EtcdKeyRequest. No redirects anymore, and in our setup it works, too.

Greetings, Marc
