### PR TITLE
fixed host / port detection in request url

### DIFF
--- a/src/main/java/mousio/etcd4j/transport/EtcdNettyClient.java
+++ b/src/main/java/mousio/etcd4j/transport/EtcdNettyClient.java
@@ -124,10 +124,10 @@ public class EtcdNettyClient implements EtcdClientImpl {
 
     URI uri = uris[connectionState.uriIndex];
 
-    // when we are called from a redirect, the url in the request contains also host and port!
-    String requestUrl = etcdRequest.getUrl();
-    if (requestUrl.contains("://")) {
-      uri = URI.create(requestUrl);
+    // when we are called from a redirect, the url in the request may also contain host and port!
+    URI requestUri = URI.create(etcdRequest.getUrl());
+    if (requestUri.getHost() != null && requestUri.getPort() > -1) {
+        uri = requestUri;
     }
 
     // Start the connection attempt.


### PR DESCRIPTION
This is a follow up fix for both https://github.com/jurmous/etcd4j/pull/7 and https://github.com/jurmous/etcd4j/pull/14: when the value(!) for an etcd request contains an url, requestUrl.contains("://") is always true, even if the request url doesn't contain host and port. A local redirect without host and port happens when the key contains a leading slash.
