### PR TITLE
Making client.delete(...).prevValue(...) work

### DIFF
--- a/src/main/java/mousio/etcd4j/EtcdClient.java
+++ b/src/main/java/mousio/etcd4j/EtcdClient.java
@@ -102,7 +102,7 @@ public class EtcdClient implements Closeable {
    * @param key to delete
    * @return EtcdKeysRequest
    */
-  public EtcdKeyRequest delete(String key) {
+  public EtcdKeyDeleteRequest delete(String key) {
     return new EtcdKeyDeleteRequest(client, key, retryHandler);
   }
 


### PR DESCRIPTION
I noticed that the sample
``` .java
etcd.delete("foo").prevValue("bar4").send();
```
(and the one with `prevIndex` probably too, haven't tested it) doesn't work, since `delete()`'s return value is `EtcdKeyRequest` and not `EtcdKeyDeleteRequest`. This PR fixes this.