### PR TITLE
Etcd v2.1: Support basic authentication 

### DIFF
--- a/src/client/java/mousio/client/retry/RetryWithExponentialBackOff.java
+++ b/src/client/java/mousio/client/retry/RetryWithExponentialBackOff.java
@@ -6,6 +6,8 @@ import mousio.client.ConnectionState;
  * Retries with an exponential backoff
  */
 public class RetryWithExponentialBackOff extends RetryPolicy {
+  public static final RetryWithExponentialBackOff DEFAULT =  new RetryWithExponentialBackOff(20, -1, 10000);
+
   private final int maxRetryCount;
   private final int maxDelay;
 

--- a/src/main/java/mousio/etcd4j/EtcdClient.java
+++ b/src/main/java/mousio/etcd4j/EtcdClient.java
@@ -4,6 +4,7 @@ import io.netty.handler.ssl.SslContext;
 import mousio.client.retry.RetryPolicy;
 import mousio.client.retry.RetryWithExponentialBackOff;
 import mousio.etcd4j.requests.*;
+import mousio.etcd4j.responses.EtcdAuthenticationException;
 import mousio.etcd4j.responses.EtcdException;
 import mousio.etcd4j.responses.EtcdVersionResponse;
 import mousio.etcd4j.transport.EtcdClientImpl;
@@ -62,7 +63,7 @@ public class EtcdClient implements Closeable {
   public String getVersion() {
     try {
       return new EtcdOldVersionRequest(this.client, retryHandler).send().get();
-    } catch (IOException | EtcdException | TimeoutException e) {
+    } catch (IOException | EtcdException | EtcdAuthenticationException | TimeoutException e) {
       return null;
     }
   }
@@ -75,7 +76,7 @@ public class EtcdClient implements Closeable {
   public EtcdVersionResponse version() {
     try {
       return new EtcdVersionRequest(this.client, retryHandler).send().get();
-    } catch (IOException | EtcdException | TimeoutException e) {
+    } catch (IOException | EtcdException | EtcdAuthenticationException | TimeoutException e) {
       return null;
     }
   }

--- a/src/main/java/mousio/etcd4j/EtcdClient.java
+++ b/src/main/java/mousio/etcd4j/EtcdClient.java
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeoutException;
  */
 public class EtcdClient implements Closeable {
   private final EtcdClientImpl client;
-  private RetryPolicy retryHandler = new RetryWithExponentialBackOff(20, -1, 10000);
+  private RetryPolicy retryHandler;
 
   /**
    * Constructor
@@ -28,20 +28,57 @@ public class EtcdClient implements Closeable {
    * @param baseUri URI to create connection on
    */
   public EtcdClient(URI... baseUri) {
-    this(null, baseUri);
+    this(EtcdSecurityContext.NONE, baseUri);
   }
 
   /**
    * Constructor
    *
-   * @param sslContext context for Ssl connections
-   * @param baseUri URI to create connection on
+   * @param username  username
+   * @param password  password
+   * @param baseUri   URI to create connection on
+   */
+  public EtcdClient(String username, String password, URI... baseUri) {
+    this(EtcdSecurityContext.withCredential(username, password), baseUri);
+  }
+
+  /**
+   * Constructor
+   *
+   * @param sslContext  context for Ssl connections
+   * @param username    username
+   * @param password    password
+   * @param baseUri     URI to create connection on
+   */
+  public EtcdClient(SslContext sslContext, String username, String password, URI... baseUri) {
+    this(new EtcdSecurityContext(sslContext, username, password), baseUri);
+  }
+
+  /**
+   * Constructor
+   *
+   * @param sslContext  context for Ssl connections
+   * @param baseUri     URI to create connection on
    */
   public EtcdClient(SslContext sslContext, URI... baseUri) {
-    if (baseUri.length == 0) {
-      baseUri = new URI[] { URI.create("https://127.0.0.1:4001") };
-    }
-    this.client = new EtcdNettyClient(sslContext, baseUri);
+    this(EtcdSecurityContext.withSslContext(sslContext), baseUri);
+  }
+
+  /**
+   * Constructor
+   *
+   * @param securityContext context for security
+   * @param baseUri URI to create connection on
+   */
+  public EtcdClient(EtcdSecurityContext securityContext, URI... baseUri) {
+    this.retryHandler = RetryWithExponentialBackOff.DEFAULT;
+
+    this.client = new EtcdNettyClient(
+      securityContext,
+      (baseUri.length == 0)
+        ? new URI[] { URI.create("https://127.0.0.1:4001") }
+        : baseUri
+    );
   }
 
   /**
@@ -174,7 +211,8 @@ public class EtcdClient implements Closeable {
    *
    * @param retryHandler to set
    */
-  public void setRetryHandler(RetryPolicy retryHandler) {
+  public EtcdClient setRetryHandler(RetryPolicy retryHandler) {
     this.retryHandler = retryHandler;
+    return this;
   }
 }

--- a/src/main/java/mousio/etcd4j/EtcdSecurityContext.java
+++ b/src/main/java/mousio/etcd4j/EtcdSecurityContext.java
@@ -1,0 +1,64 @@
+package mousio.etcd4j;
+
+import io.netty.handler.ssl.SslContext;
+
+public final class EtcdSecurityContext implements Cloneable {
+  public static final EtcdSecurityContext NONE = new EtcdSecurityContext(null, null, null);
+
+  private final SslContext sslContext;
+  private final String username;
+  private final String password;
+
+  public EtcdSecurityContext(SslContext sslContext) {
+    this(sslContext, null, null);
+  }
+
+  public EtcdSecurityContext(String username, String password) {
+    this(null, username, password);
+  }
+
+  public EtcdSecurityContext(SslContext sslContext, String username, String password) {
+    this.sslContext = sslContext;
+    this.username = username;
+    this.password = password;
+  }
+
+  public SslContext sslContext() {
+    return this.sslContext;
+  }
+
+  public String username() {
+    return username;
+  }
+
+  public String password() {
+    return password;
+  }
+
+  public boolean hasSsl() {
+    return this.sslContext != null;
+  }
+
+  public boolean hasCredentials() {
+    return this.username != null && !this.username.trim().isEmpty()
+      && this.password != null && !this.password.trim().isEmpty();
+  }
+
+  @SuppressWarnings("CloneDoesntDeclareCloneNotSupportedException")
+  @Override
+  public EtcdSecurityContext clone() {
+    try {
+      return (EtcdSecurityContext) super.clone();
+    } catch (CloneNotSupportedException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  public static EtcdSecurityContext withSslContext(SslContext sslContext) {
+    return new EtcdSecurityContext(sslContext, null, null);
+  }
+
+  public static EtcdSecurityContext withCredential(String username, String password) {
+    return new EtcdSecurityContext(null, username, password);
+  }
+}

--- a/src/main/java/mousio/etcd4j/responses/EtcdAuthenticationException.java
+++ b/src/main/java/mousio/etcd4j/responses/EtcdAuthenticationException.java
@@ -1,0 +1,16 @@
+package mousio.etcd4j.responses;
+
+/**
+ * Exception on etcd failures
+ */
+public class EtcdAuthenticationException extends Exception {
+
+  /**
+   * Constructor
+   * @param message
+   */
+  public EtcdAuthenticationException(
+    final String message) {
+    super(message);
+  }
+}

--- a/src/main/java/mousio/etcd4j/transport/AbstractEtcdResponseHandler.java
+++ b/src/main/java/mousio/etcd4j/transport/AbstractEtcdResponseHandler.java
@@ -4,9 +4,11 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.util.CharsetUtil;
 import io.netty.util.concurrent.Promise;
 import mousio.client.exceptions.PrematureDisconnectException;
 import mousio.etcd4j.requests.EtcdRequest;
+import mousio.etcd4j.responses.EtcdAuthenticationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,6 +84,8 @@ abstract class AbstractEtcdResponseHandler<RQ extends EtcdRequest, RS> extends S
       } else {
         this.promise.setFailure(new Exception("Missing Location header on redirect"));
       }
+    } if(response.status().equals(HttpResponseStatus.UNAUTHORIZED)) {
+      this.promise.setFailure(new EtcdAuthenticationException(response.content().toString(CharsetUtil.UTF_8)));
     } else {
       if (!response.content().isReadable()) {
         this.promise.setFailure(new IOException("Content was not readable. HTTP Status: "

--- a/src/main/java/mousio/etcd4j/transport/EtcdNettyConfig.java
+++ b/src/main/java/mousio/etcd4j/transport/EtcdNettyConfig.java
@@ -7,9 +7,6 @@ import io.netty.channel.socket.nio.NioSocketChannel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-
 /**
  * Settings for the etcd Netty client
  */
@@ -25,6 +22,9 @@ public class EtcdNettyConfig {
   private int maxFrameSize = 1024 * 100;
 
   private String hostName;
+
+  private String username = null;
+  private String password = null;
 
   /**
    * Constructor
@@ -119,6 +119,10 @@ public class EtcdNettyConfig {
     return this;
   }
 
+  public boolean hasHostName() {
+    return hostName != null && !hostName.trim().isEmpty();
+  }
+
   /**
    * Get the local host name
    *
@@ -137,5 +141,28 @@ public class EtcdNettyConfig {
   public EtcdNettyConfig setHostName(String hostName) {
     this.hostName = hostName;
     return this;
+  }
+
+  public boolean hasCredentials() {
+    return this.username != null && !this.username.trim().isEmpty()
+        && this.password != null && !this.password.trim().isEmpty();
+  }
+
+  public EtcdNettyConfig setUsername(String username) {
+    this.username = username;
+    return this;
+  }
+
+  public String getUsername() {
+    return this.username;
+  }
+
+  public EtcdNettyConfig setPassword(String password) {
+    this.password = password;
+    return this;
+  }
+
+  public String getPassword() {
+    return this.password;
   }
 }

--- a/src/main/java/mousio/etcd4j/transport/EtcdNettyConfig.java
+++ b/src/main/java/mousio/etcd4j/transport/EtcdNettyConfig.java
@@ -22,8 +22,6 @@ public class EtcdNettyConfig implements Cloneable {
   private int maxFrameSize = 1024 * 100;
 
   private String hostName;
-  private String username = null;
-  private String password = null;
 
   /**
    * Constructor
@@ -140,29 +138,6 @@ public class EtcdNettyConfig implements Cloneable {
   public EtcdNettyConfig setHostName(String hostName) {
     this.hostName = hostName;
     return this;
-  }
-
-  public boolean hasCredentials() {
-    return this.username != null && !this.username.trim().isEmpty()
-        && this.password != null && !this.password.trim().isEmpty();
-  }
-
-  public EtcdNettyConfig setUsername(String username) {
-    this.username = username;
-    return this;
-  }
-
-  public String getUsername() {
-    return this.username;
-  }
-
-  public EtcdNettyConfig setPassword(String password) {
-    this.password = password;
-    return this;
-  }
-
-  public String getPassword() {
-    return this.password;
   }
 
   @SuppressWarnings("CloneDoesntDeclareCloneNotSupportedException")

--- a/src/main/java/mousio/etcd4j/transport/EtcdNettyConfig.java
+++ b/src/main/java/mousio/etcd4j/transport/EtcdNettyConfig.java
@@ -10,7 +10,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Settings for the etcd Netty client
  */
-public class EtcdNettyConfig {
+public class EtcdNettyConfig implements Cloneable {
   private static final Logger logger = LoggerFactory.getLogger(EtcdNettyConfig.class);
 
   private EventLoopGroup eventLoopGroup = new NioEventLoopGroup();
@@ -22,7 +22,6 @@ public class EtcdNettyConfig {
   private int maxFrameSize = 1024 * 100;
 
   private String hostName;
-
   private String username = null;
   private String password = null;
 
@@ -164,5 +163,15 @@ public class EtcdNettyConfig {
 
   public String getPassword() {
     return this.password;
+  }
+
+  @SuppressWarnings("CloneDoesntDeclareCloneNotSupportedException")
+  @Override
+  public EtcdNettyConfig clone() {
+    try {
+      return (EtcdNettyConfig) super.clone();
+    } catch (CloneNotSupportedException e) {
+      throw new AssertionError(e);
+    }
   }
 }

--- a/src/main/java/mousio/etcd4j/transport/EtcdOldVersionResponseHandler.java
+++ b/src/main/java/mousio/etcd4j/transport/EtcdOldVersionResponseHandler.java
@@ -1,0 +1,23 @@
+package mousio.etcd4j.transport;
+
+import io.netty.handler.codec.http.FullHttpResponse;
+import mousio.etcd4j.requests.EtcdOldVersionRequest;
+
+import java.nio.charset.Charset;
+
+public class EtcdOldVersionResponseHandler extends AbstractEtcdResponseHandler<EtcdOldVersionRequest, String> {
+  /**
+   * Constructor
+   *
+   * @param etcdNettyClient the client handling connections
+   * @param etcdVersionRequest request
+   */
+  public EtcdOldVersionResponseHandler(EtcdNettyClient etcdNettyClient, EtcdOldVersionRequest etcdVersionRequest) {
+    super(etcdNettyClient, etcdVersionRequest);
+  }
+
+  @Override
+  protected String decodeResponse(FullHttpResponse response) throws Exception {
+    return response.content().toString(Charset.defaultCharset());
+  }
+}

--- a/src/test/java/mousio/etcd4j/TestFunctionality.java
+++ b/src/test/java/mousio/etcd4j/TestFunctionality.java
@@ -2,10 +2,7 @@ package mousio.etcd4j;
 
 import mousio.client.retry.RetryWithExponentialBackOff;
 import mousio.etcd4j.promises.EtcdResponsePromise;
-import mousio.etcd4j.responses.EtcdException;
-import mousio.etcd4j.responses.EtcdKeyAction;
-import mousio.etcd4j.responses.EtcdKeysResponse;
-import mousio.etcd4j.responses.EtcdVersionResponse;
+import mousio.etcd4j.responses.*;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,7 +53,7 @@ public class TestFunctionality {
   }
 
   @Test
-  public void testTimeout() throws IOException, EtcdException {
+  public void testTimeout() throws IOException, EtcdException, EtcdAuthenticationException {
     try {
       etcd.put("etcd4j_test/fooTO", "bar").timeout(1, TimeUnit.MILLISECONDS).send().get();
       fail();
@@ -69,7 +66,7 @@ public class TestFunctionality {
    * Simple value tests
    */
   @Test
-  public void testKey() throws IOException, EtcdException, TimeoutException {
+  public void testKey() throws IOException, EtcdException, EtcdAuthenticationException, TimeoutException {
     EtcdKeysResponse response = etcd.put("etcd4j_test/foo", "bar").send().get();
     assertEquals(EtcdKeyAction.set, response.action);
 
@@ -101,7 +98,7 @@ public class TestFunctionality {
    * Simple value tests
    */
   @Test
-  public void testError() throws IOException, TimeoutException {
+  public void testError() throws IOException, EtcdAuthenticationException, TimeoutException {
     try {
       etcd.get("etcd4j_test/barf").send().get();
     } catch (EtcdException e) {
@@ -119,7 +116,7 @@ public class TestFunctionality {
    * Tests redirect by sending a key with too many slashes.
    */
   @Test
-  public void testRedirect() throws IOException, EtcdException, TimeoutException {
+  public void testRedirect() throws IOException, EtcdException, EtcdAuthenticationException, TimeoutException {
     etcd.put("etcd4j_test/redirect", "bar").send().get();
 
     // Test redirect with a double slash
@@ -131,7 +128,7 @@ public class TestFunctionality {
    * Directory tests
    */
   @Test
-  public void testDir() throws IOException, EtcdException, TimeoutException {
+  public void testDir() throws IOException, EtcdException, EtcdAuthenticationException, TimeoutException {
     EtcdKeysResponse r = etcd.putDir("etcd4j_test/foo_dir").send().get();
     assertEquals(r.action, EtcdKeyAction.set);
 
@@ -157,7 +154,7 @@ public class TestFunctionality {
    * In order key tests
    */
   @Test
-  public void testInOrderKeys() throws IOException, EtcdException, TimeoutException {
+  public void testInOrderKeys() throws IOException, EtcdException, EtcdAuthenticationException, TimeoutException {
     EtcdKeysResponse r = etcd.post("etcd4j_test/queue", "Job1").send().get();
     assertEquals(r.action, EtcdKeyAction.create);
 
@@ -179,7 +176,7 @@ public class TestFunctionality {
    * In order key tests
    */
   @Test
-  public void testWait() throws IOException, EtcdException, InterruptedException, TimeoutException {
+  public void testWait() throws IOException, EtcdException, EtcdAuthenticationException, InterruptedException, TimeoutException {
     EtcdResponsePromise<EtcdKeysResponse> p = etcd.get("etcd4j_test/test").waitForChange().send();
 
     // Ensure the change is received after the listen command is received.
@@ -188,7 +185,7 @@ public class TestFunctionality {
       public void run() {
         try {
           etcd.put("etcd4j_test/test", "changed").send().get();
-        } catch (IOException | EtcdException | TimeoutException e) {
+        } catch (IOException | EtcdException | EtcdAuthenticationException | TimeoutException e) {
           fail();
         }
       }
@@ -199,7 +196,7 @@ public class TestFunctionality {
   }
 
   @Test(timeout = 1000)
-  public void testChunkedData() throws IOException, EtcdException, TimeoutException {
+  public void testChunkedData() throws IOException, EtcdException, EtcdAuthenticationException, TimeoutException {
     //creating very long key to force content to be chunked
     StringBuilder stringBuilder = new StringBuilder(15000);
     for (int i = 0; i < 15000; i++) {

--- a/src/test/java/mousio/etcd4j/transport/EtcdNettyClientTest.java
+++ b/src/test/java/mousio/etcd4j/transport/EtcdNettyClientTest.java
@@ -5,11 +5,15 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioSocketChannel;
+import mousio.etcd4j.EtcdClient;
+import mousio.etcd4j.responses.EtcdAuthenticationException;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.net.URI;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class EtcdNettyClientTest {
 
@@ -35,5 +39,35 @@ public class EtcdNettyClientTest {
     Channel channel = bootstrap.connect(uri.getHost(), uri.getPort()).sync().channel();
 
     assertEquals(100, channel.config().getOption(ChannelOption.CONNECT_TIMEOUT_MILLIS).intValue());
+  }
+
+  @Ignore
+  @Test
+  public void testAuth() throws Exception {
+    EtcdClient client = new EtcdClient(
+      new EtcdNettyClient(
+        new EtcdNettyConfig()
+          .setUsername("test")
+          .setPassword("test"),
+        null,
+        URI.create("http://localhost:4001"))
+    );
+
+    assertNotNull(client.get("/test/messages").send().get());
+  }
+
+  @Ignore
+  @Test(expected = EtcdAuthenticationException.class)
+  public void testAuthFailure() throws Exception {
+    EtcdClient client = new EtcdClient(
+      new EtcdNettyClient(
+        new EtcdNettyConfig()
+          .setUsername("test")
+          .setPassword("test_"),
+        null,
+        URI.create("http://localhost:4001"))
+    );
+
+    client.get("/test/messages").send().get();
   }
 }

--- a/src/test/java/mousio/etcd4j/transport/EtcdNettyClientTest.java
+++ b/src/test/java/mousio/etcd4j/transport/EtcdNettyClientTest.java
@@ -30,8 +30,7 @@ public class EtcdNettyClientTest {
         .setEventLoopGroup(evl)
         .setHostName("localhost");
 
-    EtcdNettyClient client = new EtcdNettyClient(config, null, uri);
-
+    EtcdNettyClient client = new EtcdNettyClient(config, uri);
     Bootstrap bootstrap = client.getBootstrap();
 
     assertEquals(evl, bootstrap.group());
@@ -45,13 +44,9 @@ public class EtcdNettyClientTest {
   @Test
   public void testAuth() throws Exception {
     EtcdClient client = new EtcdClient(
-      new EtcdNettyClient(
-        new EtcdNettyConfig()
-          .setUsername("test")
-          .setPassword("test"),
-        null,
-        URI.create("http://localhost:4001"))
-    );
+      "test",
+      "test",
+      URI.create("http://localhost:4001"));
 
     assertNotNull(client.get("/test/messages").send().get());
   }
@@ -60,13 +55,9 @@ public class EtcdNettyClientTest {
   @Test(expected = EtcdAuthenticationException.class)
   public void testAuthFailure() throws Exception {
     EtcdClient client = new EtcdClient(
-      new EtcdNettyClient(
-        new EtcdNettyConfig()
-          .setUsername("test")
-          .setPassword("test_"),
-        null,
-        URI.create("http://localhost:4001"))
-    );
+      "test",
+      "test_",
+      URI.create("http://localhost:4001"));
 
     client.get("/test/messages").send().get();
   }


### PR DESCRIPTION
I've added basic support for authentication introduced in Etcd v2.1, 

This PR is not supposed to be merged right now as there is something to be validated/discussed:
- do you want to support Etcd authentication ? :-)
- username/password can be set through EtcdNettyConfig for the moment but authentication is a property of Etcd so I think it would be better to move them in EtcdClient itself
- I've added a new EtcdAuthenticationException but maybe we can adapt EtcdException to cover more cases
