### PR TITLE
2.7.0 broke timeouts on watches

### DIFF
--- a/src/test/java/mousio/etcd4j/TestFunctionality.java
+++ b/src/test/java/mousio/etcd4j/TestFunctionality.java
@@ -198,6 +198,15 @@ public class TestFunctionality {
     assertEquals("changed", r.node.value);
   }
 
+  @Test(expected = TimeoutException.class)
+  public void testWaitTimeout() throws IOException, EtcdException, InterruptedException, TimeoutException {
+    EtcdResponsePromise<EtcdKeysResponse> p = etcd.get("etcd4j_test/test").waitForChange().timeout(10, TimeUnit.MILLISECONDS).send();
+
+    EtcdKeysResponse r = p.get();
+    // get should have thrown TimeoutException
+    fail();
+  }
+
   @Test(timeout = 1000)
   public void testChunkedData() throws IOException, EtcdException, TimeoutException {
     //creating very long key to force content to be chunked


### PR DESCRIPTION
As of 2.7.0 a timing out watch throws IOException("Content was not readable. HTTP Status: 200"), rather than a TimeoutException. I won't pretend I understand exactly how these bits work; my intuition is that the changes in 45dc09912 are the break.

Before, if a response was 200 OK but the content was not readable, the client would:

```
        if (response.status().equals(HttpResponseStatus.OK)
            || response.status().equals(HttpResponseStatus.ACCEPTED)
            || response.status().equals(HttpResponseStatus.CREATED)) {

            if (!response.content().isReadable()) {
                this.client.connect(this.request);
                return;
            }
```
Presumably it's this `connect` that threw the timeout exception?

Nowadays this just hits the branch where:

```
if (!response.content().isReadable()) {
        this.promise.setFailure(new IOException("Content was not readable. HTTP Status: "
          + response.status()));
      }
```

Attached is a test that reproduces this issue.