### PR TITLE
fix netty connect port if uri does not have port or behind some proxy like nginx

### DIFF
--- a/src/main/java/mousio/etcd4j/transport/EtcdNettyClient.java
+++ b/src/main/java/mousio/etcd4j/transport/EtcdNettyClient.java
@@ -53,8 +53,9 @@ import java.util.concurrent.CancellationException;
  */
 public class EtcdNettyClient implements EtcdClientImpl {
   private static final Logger logger = LoggerFactory.getLogger(EtcdNettyClient.class);
-  private static final int DEFAULT_PORT = 80;
 
+  // default etcd port
+  private static final int DEFAULT_PORT = 2379;
   private final EventLoopGroup eventLoopGroup;
   private final URI[] uris;
 
@@ -222,8 +223,7 @@ public class EtcdNettyClient implements EtcdClientImpl {
 
     // Start the connection attempt.
     final ChannelFuture connectFuture;
-    // uri may not have port information if behind some proxy
-    // make default port explicit 80 on connect
+    // uri may not have port information, work with default port
     if (uri.getPort() == -1) {
       connectFuture = bootstrap.clone().connect(uri.getHost(), DEFAULT_PORT);
     } else {

--- a/src/main/java/mousio/etcd4j/transport/EtcdNettyClient.java
+++ b/src/main/java/mousio/etcd4j/transport/EtcdNettyClient.java
@@ -53,6 +53,7 @@ import java.util.concurrent.CancellationException;
  */
 public class EtcdNettyClient implements EtcdClientImpl {
   private static final Logger logger = LoggerFactory.getLogger(EtcdNettyClient.class);
+  private static final int DEFAULT_PORT = 80;
 
   private final EventLoopGroup eventLoopGroup;
   private final URI[] uris;
@@ -220,7 +221,14 @@ public class EtcdNettyClient implements EtcdClientImpl {
     }
 
     // Start the connection attempt.
-    final ChannelFuture connectFuture = bootstrap.clone().connect(uri.getHost(), uri.getPort());
+    final ChannelFuture connectFuture;
+    // uri may not have port information if behind some proxy
+    // make default port explicit 80 on connect
+    if (uri.getPort() == -1) {
+      connectFuture = bootstrap.clone().connect(uri.getHost(), DEFAULT_PORT);
+    } else {
+      connectFuture = bootstrap.clone().connect(uri.getHost(), uri.getPort());
+    }
 
     final Channel channel = connectFuture.channel();
 

--- a/src/main/java/mousio/etcd4j/transport/EtcdNettyClient.java
+++ b/src/main/java/mousio/etcd4j/transport/EtcdNettyClient.java
@@ -215,6 +215,7 @@ public class EtcdNettyClient implements EtcdClientImpl {
     } else if (uris.length == 0 && System.getenv(ENV_ETCD4J_ENDPOINT) != null) {
       // read uri from environment variable
       String endpoint_uri = System.getenv(ENV_ETCD4J_ENDPOINT);
+      logger.debug("Will use environment variable " + ENV_ETCD4J_ENDPOINT + " as uri with value " + endpoint_uri);
       uri = URI.create(endpoint_uri);
     } else {
       uri = uris[connectionState.uriIndex];

--- a/src/main/java/mousio/etcd4j/transport/EtcdNettyClient.java
+++ b/src/main/java/mousio/etcd4j/transport/EtcdNettyClient.java
@@ -56,6 +56,7 @@ public class EtcdNettyClient implements EtcdClientImpl {
 
   // default etcd port
   private static final int DEFAULT_PORT = 2379;
+  private static final String ENV_ETCD4J_ENDPOINT = "ETCD4J_ENDPOINT";
   private final EventLoopGroup eventLoopGroup;
   private final URI[] uris;
 
@@ -211,7 +212,11 @@ public class EtcdNettyClient implements EtcdClientImpl {
     URI requestUri = URI.create(etcdRequest.getUrl());
     if (requestUri.getHost() != null && requestUri.getPort() > -1) {
       uri = requestUri;
-    }else{
+    } else if (uris.length == 0 && System.getenv(ENV_ETCD4J_ENDPOINT) != null) {
+      // read uri from environment variable
+      String endpoint_uri = System.getenv(ENV_ETCD4J_ENDPOINT);
+      uri = URI.create(endpoint_uri);
+    } else {
       uri = uris[connectionState.uriIndex];
     }
 


### PR DESCRIPTION
        java.lang.IllegalArgumentException: port out of range:-1
	at java.net.InetSocketAddress.checkPort(InetSocketAddress.java:143)
	at java.net.InetSocketAddress.createUnresolved(InetSocketAddress.java:254)
	at io.netty.bootstrap.Bootstrap.connect(Bootstrap.java:120)
	at mousio.etcd4j.transport.EtcdNettyClient.connect(EtcdNettyClient.java:223)
	at mousio.etcd4j.transport.EtcdNettyClient.send(EtcdNettyClient.java:178)
	at mousio.etcd4j.requests.EtcdKeyRequest.send(EtcdKeyRequest.java:75)

This tries to fix problem when given uri does not have port information attached on **EtcdNettyClient.connect**. This happens when you put your nodes in cluster behind some proxy like nginx to enable basic authentication (which by default listens port 80). 

Of course sending port information attached to **URI** when creating `EtcdClient` explicitly is another solution, let me know which one works for you.