### PR TITLE
Added API to get leader stats

### DIFF
--- a/src/main/java/mousio/etcd4j/EtcdClient.java
+++ b/src/main/java/mousio/etcd4j/EtcdClient.java
@@ -9,6 +9,7 @@ import mousio.etcd4j.responses.EtcdException;
 import mousio.etcd4j.responses.EtcdSelfStatsResponse;
 import mousio.etcd4j.responses.EtcdStoreStatsResponse;
 import mousio.etcd4j.responses.EtcdVersionResponse;
+import mousio.etcd4j.responses.EtcdLeaderStatsResponse;
 import mousio.etcd4j.transport.EtcdClientImpl;
 import mousio.etcd4j.transport.EtcdNettyClient;
 
@@ -128,6 +129,19 @@ public class EtcdClient implements Closeable {
   public EtcdSelfStatsResponse getSelfStats() {
     try {
       return new EtcdSelfStatsRequest(this.client, retryHandler).send().get();
+    } catch (IOException | EtcdException | EtcdAuthenticationException | TimeoutException e) {
+      return null;
+    }
+  }
+
+  /**
+   * Get the Leader Statistics of Etcd
+   *
+   * @return EtcdLeaderStatsResponse
+   */
+  public EtcdLeaderStatsResponse getLeaderStats() {
+    try {
+      return new EtcdLeaderStatsRequest(this.client, retryHandler).send().get();
     } catch (IOException | EtcdException | EtcdAuthenticationException | TimeoutException e) {
       return null;
     }

--- a/src/main/java/mousio/etcd4j/requests/EtcdLeaderStatsRequest.java
+++ b/src/main/java/mousio/etcd4j/requests/EtcdLeaderStatsRequest.java
@@ -1,0 +1,44 @@
+package mousio.etcd4j.requests;
+
+import io.netty.handler.codec.http.HttpMethod;
+import mousio.client.retry.RetryPolicy;
+import mousio.etcd4j.promises.EtcdResponsePromise;
+import mousio.etcd4j.responses.EtcdLeaderStatsResponse;
+import mousio.etcd4j.responses.EtcdLeaderStatsResponseDecoder;
+import mousio.etcd4j.transport.EtcdClientImpl;
+
+import java.io.IOException;
+
+
+/**
+ * @author Jurriaan Mous
+ * @author Luca Burgazzoli
+ * @author John Eke
+ *
+ * An Etcd Leader Stats Request
+ */
+public class EtcdLeaderStatsRequest extends EtcdRequest<EtcdLeaderStatsResponse> {
+
+    /**
+     * Constructor
+     *
+     * @param clientImpl   the client to handle this request
+     * @param retryHandler handles retries
+     */
+    public EtcdLeaderStatsRequest(EtcdClientImpl clientImpl, RetryPolicy retryHandler) {
+        super(clientImpl, HttpMethod.GET, retryHandler, EtcdLeaderStatsResponseDecoder.INSTANCE);
+    }
+
+    @Override public EtcdResponsePromise<EtcdLeaderStatsResponse> send() throws IOException {
+        return clientImpl.send(this);
+    }
+
+    @Override public EtcdLeaderStatsRequest setRetryPolicy(RetryPolicy retryPolicy) {
+        super.setRetryPolicy(retryPolicy);
+        return this;
+    }
+
+    @Override public String getUri() {
+        return "/v2/stats/leader";
+    }
+}

--- a/src/main/java/mousio/etcd4j/responses/EtcdLeaderStatsResponse.java
+++ b/src/main/java/mousio/etcd4j/responses/EtcdLeaderStatsResponse.java
@@ -1,0 +1,110 @@
+package mousio.etcd4j.responses;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Jurriaan Mous
+ * @author Luca Burgazzoli
+ * @author John Eke
+ *
+ * An Etcd Leader Stats Response
+ */
+public class EtcdLeaderStatsResponse {
+    private final String leader;
+    private final Map<String, EtcdLeaderStatsResponse.FollowerInfo> followers;
+
+    public EtcdLeaderStatsResponse(String leader, Map<String, EtcdLeaderStatsResponse.FollowerInfo> followers) {
+        this.leader = leader;
+        this.followers = followers;
+    }
+
+    public String getLeader() {
+        return leader;
+    }
+
+    public Map<String, EtcdLeaderStatsResponse.FollowerInfo> getFollowers() {
+        return followers;
+    }
+
+    public static class FollowerInfo {
+        private final LatencyInfo latency;
+        private final CountsInfo counts;
+
+        public FollowerInfo(
+                LatencyInfo latency,
+                CountsInfo counts
+        ) {
+            this.latency = latency;
+            this.counts = counts;
+        }
+
+        public LatencyInfo getLatency() {
+            return latency;
+        }
+
+        public CountsInfo getCounts() {
+            return counts;
+        }
+    }
+
+    public static class LatencyInfo {
+        private final double current;
+        private final double average;
+        private final double standardDeviation;
+        private final double minimum;
+        private final double maximum;
+
+        public LatencyInfo(
+                double current,
+                double average,
+                double standardDeviation,
+                double minimum,
+                double maximum
+        ) {
+            this.current = current;
+            this.average = average;
+            this.standardDeviation = standardDeviation;
+            this.minimum = minimum;
+            this.maximum = maximum;
+        }
+
+        public double getCurrent() {
+            return current;
+        }
+
+        public double getAverage() {
+            return average;
+        }
+
+        public double getStandardDeviation() {
+            return standardDeviation;
+        }
+
+        public double getMinimum() {
+            return minimum;
+        }
+
+        public double getMaximum() {
+            return maximum;
+        }
+    }
+
+    public static class CountsInfo {
+        private final long fail;
+        private final long success;
+
+        public CountsInfo(long fail, long success) {
+            this.fail = fail;
+            this.success = success;
+        }
+
+        public long getFail() {
+            return fail;
+        }
+
+        public long getSuccess() {
+            return success;
+        }
+    }
+}

--- a/src/main/java/mousio/etcd4j/responses/EtcdLeaderStatsResponseDecoder.java
+++ b/src/main/java/mousio/etcd4j/responses/EtcdLeaderStatsResponseDecoder.java
@@ -1,0 +1,182 @@
+package mousio.etcd4j.responses;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import io.netty.handler.codec.http.HttpHeaders;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Jurriaan Mous
+ * @author Luca Burgazzoli
+ * @author John Eke
+ *
+ * Parses Etcd Leader Stats Response
+ */
+public class EtcdLeaderStatsResponseDecoder extends AbstractJsonResponseDecoder<EtcdLeaderStatsResponse> {
+    public static final EtcdLeaderStatsResponseDecoder INSTANCE = new EtcdLeaderStatsResponseDecoder();
+
+    public static final String LEADER = "leader";
+    public static final String FOLLOWERS = "followers";
+
+    public static final String FOLLOWERINFO_LATENCY = "latency";
+    public static final String FOLLOWERINFO_COUNTS = "counts";
+
+    public static final String LATENCYINFO_CURRENT = "current";
+    public static final String LATENCYINFO_AVERAGE = "average";
+    public static final String LATENCYINFO_STANDARD_DEVIATION = "standardDeviation";
+    public static final String LATENCYINFO_MIN = "minimum";
+    public static final String LATENCYINFO_MAX = "maximum";
+
+    public static final String COUNTSINFO_FAIL = "fail";
+    public static final String COUNTSINFO_SUCCESS = "success";
+
+    /**
+     * Parses the Json content of the Etcd Leader StatsResponse
+     *
+     * @param headers
+     * @param parser Json parser
+     * @return EtcdLeaderStatsResponse if found in response
+     * @throws mousio.etcd4j.responses.EtcdException if exception was found in response
+     * @throws java.io.IOException                   if Json parsing or parser creation fails
+     */
+    @Override
+    protected EtcdLeaderStatsResponse decodeJson(HttpHeaders headers, JsonParser parser) throws EtcdException, IOException {
+        String leader = null;
+        Map<String, EtcdLeaderStatsResponse.FollowerInfo> followers = null;
+
+        if (parser.nextToken() == JsonToken.START_OBJECT) {
+
+            JsonToken token = parser.nextToken();
+            while (token != JsonToken.END_OBJECT && token != null) {
+
+                switch (parser.getCurrentName()) {
+                    case LEADER:
+                        leader = parser.nextTextValue();
+                        break;
+                    case FOLLOWERS:
+                        followers = parseFollowers(parser, token);
+                        break;
+                }
+
+                token = parser.nextToken();
+            }
+
+            return new EtcdLeaderStatsResponse(leader, followers);
+        }
+
+        return null;
+    }
+
+    private static Map<String, EtcdLeaderStatsResponse.FollowerInfo> parseFollowers(JsonParser parser, JsonToken token) throws EtcdException, IOException {
+        Map<String, EtcdLeaderStatsResponse.FollowerInfo> followers = new HashMap<>();
+
+        if (parser.nextToken() == JsonToken.START_OBJECT) {
+            while (token != JsonToken.END_OBJECT && token != null) {
+                String name = parser.getCurrentName();
+                switch(name) {
+                    case FOLLOWERS:
+                        break;
+                    default:
+                        followers.put(parser.getCurrentName(), parseFollowerInfo(parser, token));
+                        break;
+                }
+
+                token = parser.nextToken();
+            }
+        }
+
+        return followers;
+    }
+
+    private static EtcdLeaderStatsResponse.FollowerInfo parseFollowerInfo(JsonParser parser, JsonToken token) throws EtcdException, IOException {
+        EtcdLeaderStatsResponse.LatencyInfo latency = null;
+        EtcdLeaderStatsResponse.CountsInfo counts = null;
+
+        if (parser.nextToken() == JsonToken.START_OBJECT) {
+            while (token != JsonToken.END_OBJECT && token != null) {
+                switch (parser.getCurrentName()) {
+                    case FOLLOWERINFO_LATENCY:
+                        latency = parseLatencyInfo(parser, token);
+                        break;
+                    case FOLLOWERINFO_COUNTS:
+                        counts = parseCountsInfo(parser, token);
+                        break;
+                }
+
+                token = parser.nextToken();
+            }
+            return new EtcdLeaderStatsResponse.FollowerInfo(latency, counts);
+        }
+
+        return null;
+    }
+
+    private static EtcdLeaderStatsResponse.LatencyInfo parseLatencyInfo(JsonParser parser, JsonToken token) throws EtcdException, IOException {
+        if (parser.nextToken() == JsonToken.START_OBJECT) {
+
+            double current = 0.0;
+            double average = 0.0;
+            double standardDeviation = 0.0;
+            double minimum = 0.0;
+            double maximum = 0.0;
+
+            while (token != JsonToken.END_OBJECT && token != null) {
+                if (token == JsonToken.VALUE_NUMBER_FLOAT) {
+                    switch (parser.getCurrentName()) {
+                        case LATENCYINFO_CURRENT:
+                            current = Double.parseDouble(parser.getValueAsString());
+                            break;
+                        case LATENCYINFO_AVERAGE:
+                            average = Double.parseDouble(parser.getValueAsString());
+                            break;
+                        case LATENCYINFO_STANDARD_DEVIATION:
+                            standardDeviation = Double.parseDouble(parser.getValueAsString());
+                            break;
+                        case LATENCYINFO_MIN:
+                            minimum = Double.parseDouble(parser.getValueAsString());
+                            break;
+                        case LATENCYINFO_MAX:
+                            maximum = Double.parseDouble(parser.getValueAsString());
+                            break;
+                    }
+                }
+
+                token = parser.nextToken();
+            }
+
+            return new EtcdLeaderStatsResponse.LatencyInfo(current, average, standardDeviation, minimum, maximum);
+        }
+
+        return null;
+    }
+
+    private static EtcdLeaderStatsResponse.CountsInfo parseCountsInfo(JsonParser parser, JsonToken token) throws EtcdException, IOException {
+        if (parser.nextToken() == JsonToken.START_OBJECT) {
+
+            long fail = 0;
+            long success = 0;
+
+            while (token != JsonToken.END_OBJECT && token != null) {
+                if (token == JsonToken.VALUE_NUMBER_INT) {
+                    switch (parser.getCurrentName()) {
+                        case COUNTSINFO_FAIL:
+                            fail = parser.getLongValue();
+                            break;
+                        case COUNTSINFO_SUCCESS:
+                            success = parser.getLongValue();
+                            break;
+                    }
+                }
+
+                token = parser.nextToken();
+            }
+
+            return new EtcdLeaderStatsResponse.CountsInfo(fail, success);
+        }
+
+        return null;
+    }
+}

--- a/src/test/java/mousio/etcd4j/TestFunctionality.java
+++ b/src/test/java/mousio/etcd4j/TestFunctionality.java
@@ -5,6 +5,7 @@ import mousio.etcd4j.promises.EtcdResponsePromise;
 import mousio.etcd4j.responses.EtcdAuthenticationException;
 import mousio.etcd4j.responses.EtcdException;
 import mousio.etcd4j.responses.EtcdKeyAction;
+import mousio.etcd4j.responses.EtcdLeaderStatsResponse;
 import mousio.etcd4j.responses.EtcdKeysResponse;
 import mousio.etcd4j.responses.EtcdSelfStatsResponse;
 import mousio.etcd4j.responses.EtcdStoreStatsResponse;
@@ -76,6 +77,23 @@ public class TestFunctionality {
     assertNotNull(stats);
     assertNotNull(stats.getLeaderInfo());
     assertEquals(stats.getId(), stats.getLeaderInfo().getLeader());
+  }
+
+
+  /**
+   * Test leader Stats
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testLeaderStats() {
+    EtcdLeaderStatsResponse stats = etcd.getLeaderStats();
+    assertNotNull(stats);
+
+    // stats
+    assertNotNull(stats.getLeader());
+    assertNotNull(stats.getFollowers());
+    assertEquals(stats.getFollowers().size(), 0);
   }
 
 


### PR DESCRIPTION
Please consider my PR for adding leader stats API to etcd4j.

One thing, the tests are a bit weird. They always run against a local etcd instance, so all I could do was add a test that if there is one node running, we get back information saying that its the leader.

If you point the tests to a multi node cluster it also passes, but its hard to write that up.

One thing that can be done is if we mock etcd, then we can simulate responses to different requests.

Either way, I look forward to your feedback! :)