### PR TITLE
Added Vagrant box for etcd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ bin/
 # ignore IntelliJ idea folders and settings
 .idea/
 *.iml
+/target/
+
+# ignore vagrant files
+/.vagrant/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,12 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 3072
+  end
+  config.vm.network :forwarded_port, guest: 4001, host: 4001
+  config.vm.network :forwarded_port, guest: 2379, host: 2379
+  config.vm.provision :shell, :path => "src/integration/vagrant/provision.sh"
+end

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,8 @@ plugins {
     id 'maven'
     id 'signing'
     id 'osgi'
+    id 'org.unbroken-dome.test-sets' version '1.2.0'
+    id "com.bmuschko.vagrant" version "2.0"
 }
 
 compileJava {
@@ -37,6 +39,10 @@ ext {
 repositories {
     mavenLocal()
     mavenCentral()
+}
+
+testSets {
+    integration
 }
 
 dependencies {
@@ -138,4 +144,13 @@ uploadArchives {
             }
         }
     }
+}
+
+project.integration {
+    dependsOn vagrantUp
+    outputs.upToDateWhen { false }
+}
+
+tasks.withType(Test) {
+    reports.html.destination = file("${reporting.baseDir}/${name}")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id 'osgi'
     id 'org.unbroken-dome.test-sets' version '1.2.0'
     id "com.bmuschko.vagrant" version "2.0"
+    id 'eclipse'
 }
 
 compileJava {

--- a/src/integration/java/mousio/etcd4j/EtcdClientRule.java
+++ b/src/integration/java/mousio/etcd4j/EtcdClientRule.java
@@ -1,0 +1,70 @@
+package mousio.etcd4j;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import mousio.etcd4j.responses.EtcdVersionResponse;
+
+public class EtcdClientRule implements TestRule {
+
+  private static Logger logger = LoggerFactory.getLogger(EtcdClientRule.class);
+
+  private long wait = 100;
+  private TimeUnit waitUnit = TimeUnit.MILLISECONDS;
+  private long maxWait = 1;
+  private TimeUnit maxWaitUnit = TimeUnit.MINUTES;
+
+  private EtcdClient client;
+
+  @Override
+  public Statement apply(Statement statement, Description description) {
+    return new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        try {
+          client = new EtcdClient();
+          EtcdVersionResponse response;
+
+          long startMillis = System.currentTimeMillis();
+          while( true ) {
+            try {
+              response = client.version();
+              break;
+            }
+            catch( Throwable e ) {
+              if( (System.currentTimeMillis() - startMillis) + waitUnit.toMillis(wait) > maxWaitUnit.toMillis(maxWait)) {
+                throw new IllegalStateException("etcd server not available", e);
+              }
+              logger.info("etcd not ready, waiting {} {}", wait, waitUnit);
+              waitUnit.sleep(wait);
+            }
+          }
+
+          logger.info("etcd server {} cluster {}", response.server, response.cluster);
+
+          statement.evaluate();
+
+        }
+        finally {
+          try {
+            client.close();
+          }
+          catch(Exception e) {
+            e.printStackTrace(System.err);
+          }
+        }
+      }
+
+    };
+  }
+
+  public EtcdClient getClient() {
+    return client;
+  }
+
+}

--- a/src/integration/java/mousio/etcd4j/EtcdClientRule.java
+++ b/src/integration/java/mousio/etcd4j/EtcdClientRule.java
@@ -22,7 +22,7 @@ public class EtcdClientRule implements TestRule {
   private EtcdClient client;
 
   @Override
-  public Statement apply(Statement statement, Description description) {
+  public Statement apply(final Statement statement, final Description description) {
     return new Statement() {
       @Override
       public void evaluate() throws Throwable {

--- a/src/integration/java/mousio/etcd4j/EtcdClientRuleTest.java
+++ b/src/integration/java/mousio/etcd4j/EtcdClientRuleTest.java
@@ -1,0 +1,12 @@
+package mousio.etcd4j;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class EtcdClientRuleTest {
+  @ClassRule public static EtcdClientRule classRule = new EtcdClientRule();
+  @Test
+  public void example() {
+	  System.out.println(classRule.getClient().version().server);
+  }
+}

--- a/src/integration/vagrant/etcd.conf
+++ b/src/integration/vagrant/etcd.conf
@@ -1,0 +1,10 @@
+start on runlevel [2345]
+stop on runlevel [016]
+
+respawn
+respawn limit 10 5
+
+script
+cd /opt/etcd-v2.2.4-linux-amd64
+exec /opt/etcd-v2.2.4-linux-amd64/etcd -listen-client-urls=http://0.0.0.0:2379,http://0.0.0.0:4001 -advertise-client-urls=http://localhost:2379,http://localhost:4001 >>/var/log/etcd.log 2>&1
+end script

--- a/src/integration/vagrant/etcd.conf
+++ b/src/integration/vagrant/etcd.conf
@@ -5,6 +5,6 @@ respawn
 respawn limit 10 5
 
 script
-cd /opt/etcd-v2.2.4-linux-amd64
-exec /opt/etcd-v2.2.4-linux-amd64/etcd -listen-client-urls=http://0.0.0.0:2379,http://0.0.0.0:4001 -advertise-client-urls=http://localhost:2379,http://localhost:4001 >>/var/log/etcd.log 2>&1
+/vagrant/src/main/bash/etcd_run.sh -b 0.0.0.0 /opt/etcd-v2.2.4-linux-amd64 \
+  >>/var/log/etcd.log 2>&1
 end script

--- a/src/integration/vagrant/etcd.conf
+++ b/src/integration/vagrant/etcd.conf
@@ -1,4 +1,4 @@
-start on runlevel [2345]
+start on vagrant-mounted
 stop on runlevel [016]
 
 respawn

--- a/src/integration/vagrant/provision.sh
+++ b/src/integration/vagrant/provision.sh
@@ -2,8 +2,7 @@
 sudo apt-get update
 
 # install etcd from a github tag.
-sudo mkdir /opt/etcd-v2.2.4-linux-amd64
-curl -Ls https://github.com/coreos/etcd/releases/download/v2.2.4/etcd-v2.2.4-linux-amd64.tar.gz | sudo tar xzv --strip-components=1 -C /opt/etcd-v2.2.4-linux-amd64
+/vagrant/src/main/bash/etcd_install.sh "/opt/etcd-v2.2.4-linux-amd64"
 
 sudo cp /vagrant/src/integration/vagrant/etcd.conf /etc/init
 sudo service etcd start

--- a/src/integration/vagrant/provision.sh
+++ b/src/integration/vagrant/provision.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+sudo apt-get update
+
+# install etcd from a github tag.
+sudo mkdir /opt/etcd-v2.2.4-linux-amd64
+curl -Ls https://github.com/coreos/etcd/releases/download/v2.2.4/etcd-v2.2.4-linux-amd64.tar.gz | sudo tar xzv --strip-components=1 -C /opt/etcd-v2.2.4-linux-amd64
+
+sudo cp /vagrant/src/integration/vagrant/etcd.conf /etc/init
+sudo service etcd start
+

--- a/src/main/bash/etcd_run.sh
+++ b/src/main/bash/etcd_run.sh
@@ -1,12 +1,34 @@
 #!/usr/bin/env bash
 
+OPTIND=0
+
+while getopts ":b:" opt; do
+  case $opt in
+  	b)
+      BIND_ADDRESS=$OPTARG
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit -1
+      ;;
+  esac
+done
+shift $((OPTIND-1))
+
+ETCD_ARGS=( '--name' 'etcd4j.etcd' )
+
 if [ $# -eq 1 ]; then
     ETCD_PATH=$1
-
-    ${ETCD_PATH}/etcd \
-        --name 'etcd4j.etcd' \
-        --data-dir ${ETCD_PATH}/etcd4j.etcd &
+    ETCD_ARGS=(${ETCD_ARGS[@]} '--data-dir' "${ETCD_PATH}/etcd4j.etcd")
 else
     echo "Installation path is missing"
     exit -1
 fi
+
+if [ "${BIND_ADDRESS+x}" ]; then
+	ETCD_ARGS=(${ETCD_ARGS[@]} \
+	    "-listen-client-urls=http://${BIND_ADDRESS}:2379,http://${BIND_ADDRESS}:4001" \
+	    "-advertise-client-urls=http://localhost:2379,http://localhost:4001" )
+fi
+
+${ETCD_PATH}/etcd ${ETCD_ARGS[@]}


### PR DESCRIPTION
This PR adds Vagrant configuration for starting an etcd instance.  The instance is exposed on ports 4001 and 2379.