### PR TITLE
Removed redundant treads creation in case of custom client configuration

### DIFF
--- a/src/main/java/mousio/etcd4j/transport/EtcdNettyClient.java
+++ b/src/main/java/mousio/etcd4j/transport/EtcdNettyClient.java
@@ -19,6 +19,7 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.*;
+import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.handler.codec.base64.Base64;
@@ -128,7 +129,9 @@ public class EtcdNettyClient implements EtcdClientImpl {
     this.config = config.clone();
     this.securityContext = securityContext.clone();
     this.uris = uris;
-    this.eventLoopGroup = config.getEventLoopGroup();
+    this.eventLoopGroup = config.getEventLoopGroup() == null
+            ? new NioEventLoopGroup()
+            : config.getEventLoopGroup();
     this.bootstrap = new Bootstrap()
       .group(eventLoopGroup)
       .channel(config.getSocketChannelClass())

--- a/src/main/java/mousio/etcd4j/transport/EtcdNettyConfig.java
+++ b/src/main/java/mousio/etcd4j/transport/EtcdNettyConfig.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 public class EtcdNettyConfig implements Cloneable {
   private static final Logger logger = LoggerFactory.getLogger(EtcdNettyConfig.class);
 
-  private EventLoopGroup eventLoopGroup = new NioEventLoopGroup();
+  private EventLoopGroup eventLoopGroup = null;
 
   private boolean managedEventLoopGroup = true;
 
@@ -97,7 +97,7 @@ public class EtcdNettyConfig implements Cloneable {
    * @return itself for chaining.
    */
   public EtcdNettyConfig setEventLoopGroup(EventLoopGroup eventLoopGroup, boolean managed) {
-    if (this.managedEventLoopGroup) { // if i manage it, close the old when new one come
+    if (this.eventLoopGroup != null && this.managedEventLoopGroup) { // if i manage it, close the old when new one come
       this.eventLoopGroup.shutdownGracefully();
     }
     this.eventLoopGroup = eventLoopGroup;


### PR DESCRIPTION
Hello, 

Have noticed that if create EtcdClient with custom configuration, in particular supplying external ```NioEvenLoopGroup```, the ```EtcdNettyConfig``` is still creating new ```NioEvenLoopGroup``` instance which in turn causes creation of default number of threads for the sort period of time (approx 2 seconds).

Code of the client creation:
```java
 private EtcdClient createEtcdClient(EventLoopGroup ioGroup, EtcdSettings settings) {
        final EtcdNettyConfig etcdNettyConfig = new EtcdNettyConfig();
        etcdNettyConfig.setEventLoopGroup(ioGroup, false);
        etcdNettyConfig.setConnectTimeout((int) settings.nodeConnectionTimeoutMillis());

        final URI[] nodes = settings
                .nodes()
                .stream()
                .toArray(URI[]::new);

        return new EtcdClient(new EtcdNettyClient(etcdNettyConfig, (SslContext)null, nodes))
                .setRetryHandler(NoRetry.instance());
    }
```

The issue caused by this code:
```java
public class EtcdNettyConfig implements Cloneable {
  // ...
  private EventLoopGroup eventLoopGroup = new NioEventLoopGroup();
```
And looks like this in profiler:
<img width="189" alt="boot_foo_-__boo_-_yourkit_java_profiler_2017_02-b53_-_64-bit" src="https://cloud.githubusercontent.com/assets/814206/23797455/3c2dfcec-05a0-11e7-81c0-1c09606433ec.png">

So here is small PR to fix it.