### PR TITLE
Change the Netty maxFrameSize to 100Mb

### DIFF
--- a/src/main/java/mousio/etcd4j/transport/EtcdNettyConfig.java
+++ b/src/main/java/mousio/etcd4j/transport/EtcdNettyConfig.java
@@ -38,7 +38,7 @@ public class EtcdNettyConfig implements Cloneable {
 
   private int connectTimeout = 300;
 
-  private int maxFrameSize = 1024 * 100;
+  private int maxFrameSize = 1024 * 1024 * 100;
 
   private String hostName;
 


### PR DESCRIPTION
Before, this was set to 100Kb which caused problems with large request responses. This made it seem like etcd4j froze, when it actually was retrying forever because of that the response was larger than 100kb.