### PR TITLE
Fixed flattener issues when json keys contain dots

### DIFF
--- a/src/main/java/mousio/etcd4j/EtcdUtil.java
+++ b/src/main/java/mousio/etcd4j/EtcdUtil.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.wnameless.json.flattener.FlattenMode;
 import com.github.wnameless.json.flattener.JsonFlattener;
+import com.github.wnameless.json.flattener.KeyTransformer;
 import com.github.wnameless.json.unflattener.JsonUnflattener;
 import io.netty.handler.codec.http.HttpHeaders;
 import mousio.etcd4j.requests.EtcdKeyGetRequest;
@@ -131,7 +132,12 @@ public class EtcdUtil {
     Map<String, Object> flattened = new JsonFlattener(EtcdUtil.jsonToString(data))
             .withFlattenMode(FlattenMode.MONGODB)
             .withSeparator('/')
-            .withKeyTransformer(s -> s.replaceAll("\\.", "__DOT__"))
+            .withKeyTransformer(new KeyTransformer() {
+              @Override
+              public String transform(String s) {
+                return s.replaceAll("\\.", "__DOT__");
+              }
+            })
             .flattenAsMap();
 
     // clean previous data and replace it with new json structure
@@ -159,7 +165,12 @@ public class EtcdUtil {
   private static JsonNode dotNotationToStandardJson(JsonNode etcdJson) throws IOException {
     String unflattened = new JsonUnflattener(jsonToString(flattenJson(etcdJson, "")))
             .withFlattenMode(FlattenMode.MONGODB)
-            .withKeyTransformer(s -> s.replaceAll("__DOT__", "\\."))
+            .withKeyTransformer(new KeyTransformer() {
+              @Override
+              public String transform(String s) {
+                return s.replaceAll("__DOT__", "\\.");
+              }
+            })
             .unflatten();
     return mapper.readTree(unflattened);
   }

--- a/src/main/java/mousio/etcd4j/EtcdUtil.java
+++ b/src/main/java/mousio/etcd4j/EtcdUtil.java
@@ -131,6 +131,7 @@ public class EtcdUtil {
     Map<String, Object> flattened = new JsonFlattener(EtcdUtil.jsonToString(data))
             .withFlattenMode(FlattenMode.MONGODB)
             .withSeparator('/')
+            .withKeyTransformer(s -> s.replaceAll("\\.", "__DOT__"))
             .flattenAsMap();
 
     // clean previous data and replace it with new json structure
@@ -158,6 +159,7 @@ public class EtcdUtil {
   private static JsonNode dotNotationToStandardJson(JsonNode etcdJson) throws IOException {
     String unflattened = new JsonUnflattener(jsonToString(flattenJson(etcdJson, "")))
             .withFlattenMode(FlattenMode.MONGODB)
+            .withKeyTransformer(s -> s.replaceAll("__DOT__", "\\."))
             .unflatten();
     return mapper.readTree(unflattened);
   }

--- a/src/test/java/mousio/client/util/EtcdJsonTest.java
+++ b/src/test/java/mousio/client/util/EtcdJsonTest.java
@@ -80,7 +80,7 @@ public class EtcdJsonTest {
         assertEquals(widget.getNode().getNodes().size(), 1);
 
         EtcdKeysResponse widgets = etcd.get("/etcd4j_test/put-json/widget").send().get();
-        assertEquals(widgets.getNode().getNodes().size(), 4);
+        assertEquals(widgets.getNode().getNodes().size(), 5);
     }
 
     @Test

--- a/src/test/resources/test_data.json
+++ b/src/test/resources/test_data.json
@@ -23,6 +23,7 @@
       "vOffset": 100,
       "alignment": "center",
       "onMouseUp": "sun1.opacity = (sun1.opacity / 100) * 90;"
-    }
+    },
+    "10.200.1.198": "{\"ip\":\"10.200.1.198\",\"cluster_id\":\"1.0.0.1\"}"
   }
 }


### PR DESCRIPTION
When a json key contained dots (such as an IP address), the flattening algorithm crashed returning nonsense