### PR TITLE
Prevent exceptions when fetching large numbers

### DIFF
--- a/src/main/java/mousio/etcd4j/EtcdUtil.java
+++ b/src/main/java/mousio/etcd4j/EtcdUtil.java
@@ -15,6 +15,7 @@
  */
 package mousio.etcd4j;
 
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -55,6 +56,7 @@ public class EtcdUtil {
 
   static {
     mapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+    mapper.configure(JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS, true);
   }
 
   public static Long getHeaderPropertyAsLong(HttpHeaders headers, String key) {

--- a/src/test/java/mousio/client/util/EtcdJsonTest.java
+++ b/src/test/java/mousio/client/util/EtcdJsonTest.java
@@ -265,6 +265,6 @@ public class EtcdJsonTest {
         JsonNode toEtcd = EtcdUtil.stringToJson("{\"number\": \"16161651321274258257474247745577454547774545785547\"}");
         EtcdUtil.putAsJson("/etcd4j_test/put-json", toEtcd, etcd);
         JsonNode asJson = EtcdUtil.getAsJson("/etcd4j_test/put-json", etcd);
-        assertEquals("Infinity", asJson.get("number").toString());
+        assertEquals("\"Infinity\"", asJson.get("number").toString());
     }
 }

--- a/src/test/java/mousio/client/util/EtcdJsonTest.java
+++ b/src/test/java/mousio/client/util/EtcdJsonTest.java
@@ -260,4 +260,11 @@ public class EtcdJsonTest {
         assertEquals(updatedConfig.at("/widget/test").asText(), "value");
     }
 
+    @Test
+    public void testGetLargeNumbers() throws EtcdAuthenticationException, TimeoutException, EtcdException, IOException {
+        JsonNode toEtcd = EtcdUtil.stringToJson("{\"number\": \"16161651321274258257474247745577454547774545785547\"}");
+        EtcdUtil.putAsJson("/etcd4j_test/put-json", toEtcd, etcd);
+        JsonNode asJson = EtcdUtil.getAsJson("/etcd4j_test/put-json", etcd);
+        assertEquals("Infinity", asJson.get("number").toString());
+    }
 }


### PR DESCRIPTION
If some large number is stored in etcd (as string), when unmarshalling using the JSON utilities a fatal exception occurred. 