### PR TITLE
Replace javax.xml.bind.DatatypeConverter usage (fixes Java 11+ compatibility)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,8 @@ plugins {
 }
 
 compileJava {
-    sourceCompatibility = 1.7
-    targetCompatibility = 1.7
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
 }
 
 group = 'org.mousio'

--- a/src/main/java/mousio/etcd4j/EtcdUtil.java
+++ b/src/main/java/mousio/etcd4j/EtcdUtil.java
@@ -16,13 +16,13 @@
 package mousio.etcd4j;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
-import javax.xml.bind.DatatypeConverter;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -98,7 +98,7 @@ public class EtcdUtil {
   }
 
   public static Date convertDate(String date) {
-    return DatatypeConverter.parseDateTime(date).getTime();
+    return Date.from(Instant.parse(date));
   }
 
   /**


### PR DESCRIPTION
This PR bumps minimum Java compatibility to Java 8 and fixes the date parsing method which does not work as of Java 11 (or 9+ without adding the JAXB module explicitly) and newer versions.

Bumping minimum Java version to 8 is needed because neither `Date.from(Instant)` or `Instant.parse(CharSequence)` are present in Java 7.